### PR TITLE
Improve results display and support additional genotypes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -324,6 +324,20 @@ function flipOrientation (genotype: string): string {
     .join('')
 }
 
+function flipOrder (genotype: string): string {
+  return genotype[1] + genotype[0]
+}
+
+function isMatch (genotype: string, pathogenic: string[]) {
+  const flipped = flipOrientation(genotype)
+  return (
+    pathogenic.includes(genotype) ||
+    pathogenic.includes(flipOrder(genotype)) ||
+    pathogenic.includes(flipped) ||
+    pathogenic.includes(flipOrder(flipped))
+  )
+}
+
 function prioritySort (variants: Variant[]): Record<string, Variant[]> {
   const priorityOrder = ['DNA Methylation', 'Estrogen Deactivation']
 
@@ -399,7 +413,7 @@ function renderTable (elements: Elements, foundSnps: Variant[], mpsData: MpsData
         const td = document.createElement('td')
         const content = escapeHtml(String(snp[column]))
         td.innerHTML = column === 'rsid' ? linkToSnpedia(content) : content
-        if(mpsData[snp.rsid].pathogenic.includes(snp.genotype) || mpsData[snp.rsid].pathogenic.includes(flipOrientation(snp.genotype))) {
+        if(isMatch(snp.genotype, mpsData[snp.rsid].pathogenic)) {
           td.setAttribute('style', 'color:#f00;border-color:black;font-weight:bold')
         } else {
           td.setAttribute('style', 'color:#777;border-color:black;font-style:italic')

--- a/src/index.ts
+++ b/src/index.ts
@@ -393,6 +393,7 @@ function renderTable (elements: Elements, foundSnps: Variant[], mpsData: MpsData
 
     sortedGroups[phenotype].forEach(snp => {
       const tr = document.createElement('tr')
+      tr.setAttribute('style', 'font-family:monospace')
 
       columns.forEach(column => {
         const td = document.createElement('td')

--- a/src/index.ts
+++ b/src/index.ts
@@ -430,7 +430,7 @@ function renderTable (elements: Elements, foundSnps: Variant[], mpsData: MpsData
 function renderReportDownload (elements: Elements, foundSnps: Variant[]): void {
   const button = document.createElement('button')
   button.textContent = 'Save Report'
-  button.onclick = () => { downloadCSV(foundSnps) }
+  button.onclick = () => { downloadTSV(foundSnps) }
 
   // Insert the button after the table
   elements.saveReportBtn.innerHTML = ''
@@ -448,24 +448,24 @@ function groupBy (arr: Variant[], key: keyof Variant): Record<string, Variant[]>
   }, {})
 }
 
-function convertToCSV (arrayOfObjects: any[]): string {
+function convertToTSV (arrayOfObjects: any[]): string {
   const keys = Object.keys(arrayOfObjects[0])
-  const values = arrayOfObjects.map(obj => keys.map(key => obj[key]).join(','))
-  return [keys.join(','), ...values].join('\n')
+  const values = arrayOfObjects.map(obj => keys.map(key => obj[key]).join('\t'))
+  return [keys.join('\t'), ...values].join('\n')
 }
 
-function downloadCSV (obj: any[]): void {
-  // Convert the object to CSV
-  const csv = convertToCSV(obj)
+function downloadTSV (obj: any[]): void {
+  // Convert the object to TSV
+  const tsv = convertToTSV(obj)
 
-  // Create a blob from the CSV string
-  const blob = new Blob([csv], { type: 'text/csv' })
+  // Create a blob from the TSV string
+  const blob = new Blob([tsv], { type: 'text/tab-separated-values' })
 
   // Create a hidden link and attach the blob
   const a = document.createElement('a')
   a.style.display = 'none'
   a.href = URL.createObjectURL(blob)
-  a.download = 'meyer-powers-report.csv'
+  a.download = 'meyer-powers-report.tsv'
 
   // Append the link to the body
   document.body.appendChild(a)


### PR DESCRIPTION
I apologize for this being so large.  I was developing it in my own direction for personal use, but ended-up fixing enough things / adding enough functionality that I decided it would be worth seeing if it's something you're interested in merging.

This fixes #7, #8, #9, and #10.

- All present SNPs now show on the report, even if they're not a match
  - Matched SNPs display in red and bold
  - Unmatched SNPs display in italics
- Indels are supported
- Heterozygous pathogenic traits are supported
- Multiple pathogenic genes are supported (this might have also worked originally)
- Broken CSV exports have been changed to not-broken TSV exports

Wishlist:  Limit TSV just to matches (nice to have, but not interested in implementing myself)  
Note:  Have only tested with AncestryDNA.  Not sure how others specify indels;  may need to specify novel complements for "I" and "D" to support other notations.  