### PR TITLE
Fixed parsing issue in AncestryDNA & 23andMe data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/node
 # Edit at https://www.toptal.com/developers/gitignore?templates=node
 
+### macOS ###
+*.DS_Store 
+
 ### Node ###
 # Logs
 logs

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,7 +6,7 @@ describe('JSON structure test', () => {
 		const data = fs.readFileSync('./static/mps/mps-data.json', 'utf8');
 		const json = JSON.parse(data);
 
-		const geneVariantFields = ['phenotype', 'pathogenic', 'gene', 'notes'];
+		const geneVariantFields = ['phenotype', 'pathogenic', 'onForwardStrand', 'gene', 'notes'];
 
 		Object.values(json).forEach((geneVariant: any) => {
 			Object.keys(geneVariant).forEach(function (geneVariantField) {

--- a/src/lib/models/GeneDataParser.ts
+++ b/src/lib/models/GeneDataParser.ts
@@ -121,7 +121,7 @@ export class GeneDataParser {
       }
       const snp = row[0]
       if (snp in mpsData) {
-        foundSnps.push(new GeneVariant({
+        let foundSnp = new GeneVariant({
           gene: mpsData[snp].gene,
           rsid: snp,
           chromosome: row[1],
@@ -129,7 +129,11 @@ export class GeneDataParser {
           genotype: Genotype.fromString(row[3]),
           phenotype: mpsData[snp].phenotype,
           pathogenic: mpsData[snp].pathogenic.map(Genotype.fromString).filter(item => item !== null),
-        }))
+        });
+        if (mpsData[snp].onForwardStrand == false) {
+          foundSnp.genotype = Genotype.fromOppositeStrandTo(foundSnp.genotype);
+        }
+        foundSnps.push(foundSnp);
       }
     })
     return foundSnps
@@ -144,7 +148,7 @@ export class GeneDataParser {
       }
       const snp = row[0]
       if (snp in mpsData) {
-        foundSnps.push(new GeneVariant({
+        let foundSnp = new GeneVariant({
           gene: mpsData[snp].gene,
           rsid: snp,
           chromosome: row[1],
@@ -152,7 +156,11 @@ export class GeneDataParser {
           genotype: Genotype.fromString(row[3] + row[4]),
           phenotype: mpsData[snp].phenotype,
           pathogenic: mpsData[snp].pathogenic.map(Genotype.fromString).filter(item => item !== null),
-        }))
+        });
+        if (mpsData[snp].onForwardStrand == false) {
+          foundSnp.genotype = Genotype.fromOppositeStrandTo(foundSnp.genotype);
+        }
+        foundSnps.push(foundSnp);
       }
     })
     return foundSnps

--- a/src/lib/models/Genotype.ts
+++ b/src/lib/models/Genotype.ts
@@ -35,6 +35,44 @@ export class Genotype {
   }
 
   /**
+   * Constructs a paired Genotype from an existing one, as if it were read from the opposite strand.
+   * This is needed when parsing AncestryDNA and 23andMe files, which report all SNPs in plus/forward
+   * orientation, whereas SNPedia reports individual SNPs as either plus/forward or minus/reverse, 
+   * depending on the reference standard. For details, see: https://www.snpedia.com/index.php/Orientation
+   */
+  public static fromOppositeStrandTo(original: Genotype | null) : Genotype | null {
+    if (original === null) {
+      return null;
+    }
+    else {
+      let pairedAlleles : Nucleotide[] = [];
+      original.alleles.forEach(n => {
+        switch (n) {
+          case Nucleotide.A: {
+            pairedAlleles.push(Nucleotide.T);
+            break;
+          }
+          case Nucleotide.T: {
+            pairedAlleles.push(Nucleotide.A);
+            break;
+          }
+          case Nucleotide.C: {
+            pairedAlleles.push(Nucleotide.G);
+            break;
+          }
+          case Nucleotide.G: {
+            pairedAlleles.push(Nucleotide.C);
+            break;
+          }
+          default:
+            return null;
+        }
+      });
+      return new Genotype(pairedAlleles);
+    }
+  }
+
+  /**
    * Returns true if every allele on this {@link Genotype} 
    * @param other The other {@link Genotype}
    */

--- a/src/lib/models/MpsData.ts
+++ b/src/lib/models/MpsData.ts
@@ -1,5 +1,6 @@
 export type MpsData = Record<string, {
   phenotype: string
   pathogenic: string[]
+  onForwardStrand: boolean | null
   gene: string
 }>

--- a/static/mps/mps-data.json
+++ b/static/mps/mps-data.json
@@ -2,6 +2,7 @@
     "rs2476601": {
         "phenotype": "Addison's Disease",
         "pathogenic": ["AA", "AG"],
+        "onForwardStrand": true,
         "gene": "AP4B1-AS1,PTPN22"
     },
     "rs11571303": {
@@ -12,6 +13,7 @@
     "rs1464510": {
         "phenotype": "Addison's Disease",
         "pathogenic": ["AA"],
+        "onForwardStrand": false,
         "gene": "LPP"
     },
     "rs3998178": {
@@ -22,11 +24,13 @@
     "rs10806425": {
         "phenotype": "Addison's Disease",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "BACH2"
     },
     "rs7137828": {
         "phenotype": "Addison's Disease",
         "pathogenic": [],
+        "onForwardStrand": true,
         "gene": "ATXN2"
     },
     "rs8112143": {
@@ -37,6 +41,7 @@
     "rs11203203": {
         "phenotype": "Addison's Disease",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "UBASH3A"
     },
     "rs74203920": {
@@ -47,131 +52,157 @@
     "rs2075876": {
         "phenotype": "Addison's Disease",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "AIRE"
     },
     "rs1801133": {
         "phenotype": "Folate Cycle",
         "pathogenic": ["TT", "CT"],
+        "onForwardStrand": false,
         "gene": "MTHFR"
     },
     "rs1801131": {
         "phenotype": "Folate Cycle",
         "pathogenic": ["CC", "AC"],
+        "onForwardStrand": false,
         "gene": "MTHFR"
     },
     "rs2236225": {
         "phenotype": "Folate Cycle",
         "pathogenic": ["TT", "CT"],
+        "onForwardStrand": false,
         "gene": "MTHFD1"
     },
     "rs1950902": {
         "phenotype": "Folate Cycle",
         "pathogenic": ["CC"],
+        "onForwardStrand": false,
         "gene": "MTHFD1"
     },
     "rs6922269": {
         "phenotype": "Folate Cycle",
         "pathogenic": ["AA", "AG"],
+        "onForwardStrand": true,
         "gene": "MTHFD1L"
     },
     "rs1802059": {
         "phenotype": "Folate Cycle",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "MTRR"
     },
     "rs2470152": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["CC"],
+        "onForwardStrand": false,
         "gene": "CYP19A1 - Aromatase"
     },
     "rs4646": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["CC"],
+        "onForwardStrand": true,
         "gene": "CYP19A1 - Aromatase"
     },
     "rs2470144": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GG"],
+        "onForwardStrand": false,
         "gene": "CYP19A1 - Aromatase",
         "notes": "Aromatase #3 (Minor)"
     },
     "rs10046": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["TT"],
+        "onForwardStrand": false,
         "gene": "CYP19A1 - Aromatase"
     },
     "rs2414096": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GG"],
+        "onForwardStrand": true,
         "gene": "CYP19A1 - Aromatase",
         "notes": "PCOS"
     },
     "rs78310315": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["CT"],
+        "onForwardStrand": true,
         "gene": "CYP19A1 - Aromatase"
     },
     "rs17036314": {
         "phenotype": "Insulin Resistance",
         "pathogenic": ["CC", "CG"],
+        "onForwardStrand": true,
         "gene": "PPARG"
     },
     "rs5219": {
         "phenotype": "Insulin Resistance",
         "pathogenic": ["TT", "CT"],
+        "onForwardStrand": true,
         "gene": "KCNJ11"
     },
     "rs2943634": {
         "phenotype": "Insulin Resistance",
         "pathogenic": ["CC"],
+        "onForwardStrand": true,
         "gene": "(pseudogene)"
     },
     "rs1800796": {
         "phenotype": "Inflammation Marker",
         "pathogenic": ["CC", "CG"],
+        "onForwardStrand": true,
         "gene": "IL6,LOC541472"
     },
     "rs3761847": {
         "phenotype": "Inflammation Marker",
         "pathogenic": ["GG", "AG"],
+        "onForwardStrand": true,
         "gene": "TRAF1"
     },
     "rs429358": {
         "phenotype": "LDL Cholesterol",
         "pathogenic": ["CC", "CT"],
+        "onForwardStrand": true,
         "gene": "APOE"
     },
     "rs7412": {
         "phenotype": "LDL Cholesterol",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "APOE"
     },
     "rs75932628": {
+        "onForwardStrand": true,
         "phenotype": "LDL Cholesterol",
         "pathogenic": ["TT", "CT"],
         "gene": "TREM2"
     },
     "rs4420638": {
+        "onForwardStrand": true,
         "phenotype": "LDL Cholesterol",
         "pathogenic": ["GG", "AG"],
         "gene": "APOC1"
     },
     "rs1800795": {
+        "onForwardStrand": true,
         "phenotype": "LDL Cholesterol",
         "pathogenic": ["GG"],
         "gene": "IL6,LOC541472"
     },
     "rs165599": {
+        "onForwardStrand": true,
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GG"],
         "gene": "COMT"
     },
     "rs165722": {
+        "onForwardStrand": true,
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["CC"],
         "gene": "COMT"
     },
     "rs776746": {
+        "onForwardStrand": false,
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GG"],
         "gene": "CYP3A5,ZSCAN25"
@@ -179,202 +210,242 @@
     "rs762551": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP1A2"
     },
     "rs743572": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GG"],
+        "onForwardStrand": true,
         "gene": "CYP17A1"
     },
     "rs4680": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": [],
+        "onForwardStrand": true,
         "gene": "COMT"
     },
     "rs4633": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["TT", "CT"],
+        "onForwardStrand": true,
         "gene": "COMT,MIR4761"
     },
     "rs104893956": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["CT"],
+        "onForwardStrand": true,
         "gene": "ESR1"
     },
     "rs121913044": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["AT"],
+        "onForwardStrand": true,
         "gene": "ESR1"
     },
     "rs397509428": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GT"],
+        "onForwardStrand": true,
         "gene": "ESR1"
     },
     "rs9340799": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GG"],
+        "onForwardStrand": true,
         "gene": "ESR1"
     },
     "rs2881766": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GT", "TT"],
+        "onForwardStrand": true,
         "gene": "ESR1"
     },
     "rs2295190": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": ["GT", "TT"],
+        "onForwardStrand": true,
         "gene": "ESR1"
     },
     "rs165631": {
         "phenotype": "Estrogen Signaling",
         "pathogenic": [],
+        "onForwardStrand": true,
         "gene": "COMT",
         "notes": "Perhaps slightly lower risk for breast cancer in BRCA1/2 mutation carriers"
     },
     "rs398124239": {
         "phenotype": "Hypermobility RS2",
         "pathogenic": ["DD"],
+        "onForwardStrand": true,
         "gene": "RP2"
     },
     "i5005436": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs151344503": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2,TNXB"
     },
     "rs201552310": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs267606756": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs267606757": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["CC"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs387906510": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["DD"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs397509367": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["CC"],
+        "onForwardStrand": true,
         "gene": "CYP21A2,TNXB"
     },
     "rs6445": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2,TNXB"
     },
     "rs6467": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["CC"],
+        "onForwardStrand": false,
         "gene": "CYP21A2"
     },
     "rs6471": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs6472": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["CC"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs6475": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs6476": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs7755898": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs7769409": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs9378251": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs151344504": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2,TNXB"
     },
     "rs151344505": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs151344506": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2,TNXB"
     },
     "rs397515532": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs72552754": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs72552756": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["CC"],
+        "onForwardStrand": true,
         "gene": "CYP21A2,TNXB"
     },
     "rs72552757": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2,TNXB"
     },
     "rs72552758": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP21A2,TNXB"
     },
     "rs9378252": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["TT"],
+        "onForwardStrand": true,
         "gene": "CYP21A2"
     },
     "rs12086634": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["GG"],
+        "onForwardStrand": true,
         "gene": "HSD11B1"
     },
     "rs28934586": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["GG"],
+        "onForwardStrand": true,
         "gene": "CYP11B1"
     },
-    "rs201103987" : {
+    "rs201103987": {
         "phenotype": "Congenital Adrenal Hyperplasia",
         "pathogenic": ["AA"],
+        "onForwardStrand": true,
         "gene": "CYP11B1"
     }
 }


### PR DESCRIPTION
(see issue #30 for discussion)

- Added SNP "orientation" from SNPedia to MpsData (see https://www.snpedia.com/index.php/Orientation for details)
- Added a method to Genotype.ts to create a 'paired' genotype from an existing one, having the opposite orientation
- Modified GeneDataParser.ts to substitute a paired genotype when an SNP's orientation in the raw data does not match SNPedia
- Update index.test.ts to validate MpsData.json