### PR TITLE
Limit reassignment

### DIFF
--- a/src/lib/models/GeneDataParser.ts
+++ b/src/lib/models/GeneDataParser.ts
@@ -121,18 +121,20 @@ export class GeneDataParser {
       }
       const snp = row[0]
       if (snp in mpsData) {
-        let foundSnp = new GeneVariant({
+        const onForward = mpsData[snp].onForwardStrand ?? true;
+        let genotype = Genotype.fromString(row[3]);
+        if (!onForward) {
+          genotype = genotype?.fromOppositeStrand() ?? null;
+        }
+        const foundSnp = new GeneVariant({
           gene: mpsData[snp].gene,
           rsid: snp,
           chromosome: row[1],
           position: row[2],
-          genotype: Genotype.fromString(row[3]),
+          genotype: genotype,
           phenotype: mpsData[snp].phenotype,
           pathogenic: mpsData[snp].pathogenic.map(Genotype.fromString).filter(item => item !== null),
         });
-        if (mpsData[snp].onForwardStrand == false) {
-          foundSnp.genotype = Genotype.fromOppositeStrandTo(foundSnp.genotype);
-        }
         foundSnps.push(foundSnp);
       }
     })
@@ -148,18 +150,20 @@ export class GeneDataParser {
       }
       const snp = row[0]
       if (snp in mpsData) {
-        let foundSnp = new GeneVariant({
+        const onForward = mpsData[snp].onForwardStrand ?? true;
+        let genotype = Genotype.fromString(row[3] + row[4]);
+        if (!onForward) {
+          genotype = genotype?.fromOppositeStrand() ?? null;
+        }
+        const foundSnp = new GeneVariant({
           gene: mpsData[snp].gene,
           rsid: snp,
           chromosome: row[1],
           position: row[2],
-          genotype: Genotype.fromString(row[3] + row[4]),
+          genotype: genotype,
           phenotype: mpsData[snp].phenotype,
           pathogenic: mpsData[snp].pathogenic.map(Genotype.fromString).filter(item => item !== null),
         });
-        if (mpsData[snp].onForwardStrand == false) {
-          foundSnp.genotype = Genotype.fromOppositeStrandTo(foundSnp.genotype);
-        }
         foundSnps.push(foundSnp);
       }
     })

--- a/src/lib/models/Genotype.ts
+++ b/src/lib/models/Genotype.ts
@@ -35,17 +35,18 @@ export class Genotype {
   }
 
   /**
-   * Constructs a paired Genotype from an existing one, as if it were read from the opposite strand.
+   * Returns a new genotype as if this genotype were read from the opposite strand.
    * This is needed when parsing AncestryDNA and 23andMe files, which report all SNPs in plus/forward
    * orientation, whereas SNPedia reports individual SNPs as either plus/forward or minus/reverse, 
    * depending on the reference standard. For details, see: https://www.snpedia.com/index.php/Orientation
    */
-  public static fromOppositeStrandTo(original: Genotype | null) : Genotype | null {
+  fromOppositeStrand(): Genotype | null {
+    const original = this;
     if (original === null) {
       return null;
     }
     else {
-      let pairedAlleles : Nucleotide[] = [];
+      let pairedAlleles: Nucleotide[] = [];
       original.alleles.forEach(n => {
         switch (n) {
           case Nucleotide.A: {


### PR DESCRIPTION
Hello @mirikoz ! Sorry, I wasn't able to leave comments on your MR. Because it has already been merged, I'm submitting this MR to ever so slightly tweak your changes. 😅 

The spirit of this MR is in limiting the scope of mutations/assignments.
e.g. instead of `foundSnp.genotype = foo`, we limit reassignment to `genotype` before constructing the `foundSnp`. This limits the opportunity for certain bugs, and improves readability.

Indeed, I would have preferred to avoid reassignment altogether, but the purely functional implementation sacrificed some readability.

I've also converted the `fromOppositeStrandTo` into an instance method so that `this` can be used to refer to the `original`.